### PR TITLE
Fix preview layer orientation in photo mode

### DIFF
--- a/Source/PBJVision.m
+++ b/Source/PBJVision.m
@@ -754,6 +754,7 @@ typedef void (^PBJVisionBlock)();
     
         if (_previewLayer && _previewLayer.session != _captureSession) {
             _previewLayer.session = _captureSession;
+            [self _setOrientationForConnection:_previewLayer.connection];
         }
         
         if (![_captureSession isRunning]) {


### PR DESCRIPTION
If only using photo mode, the preview layer wasn't respecting the developer-set orientation mode. This fixes that issue.
