### PR TITLE
Remove the observers to PBJCamera on dealloc

### DIFF
--- a/Source/PBJVision.m
+++ b/Source/PBJVision.m
@@ -355,6 +355,7 @@ enum
     }
     
     [self _destroyGL];
+    [self _destroyCamera];
 }
 
 #pragma mark - queue helper methods


### PR DESCRIPTION
I have multiple instances of PBJCamera in my application.  Without this fix, when I pop my VC that's holding on to an instance of the camera, it gets deallocated while still being observed.  This will fix that.

(Side note, this is a nice library, thanks!)
