### PR TITLE
Set _assetWriter.shouldOptimizeForNetworkUse = YES

### DIFF
--- a/Source/PBJVision.m
+++ b/Source/PBJVision.m
@@ -1285,6 +1285,7 @@ typedef void (^PBJVisionBlock)();
 
         NSError *error = nil;
         _assetWriter = [[AVAssetWriter alloc] initWithURL:_outputURL fileType:(NSString *)kUTTypeQuickTimeMovie error:&error];
+        _assetWriter.shouldOptimizeForNetworkUse = YES;
         if (error) {
             DLog(@"error setting up the asset writer (%@)", error);
             _assetWriter = nil;


### PR DESCRIPTION
When the value of this property is YES, the output file will be
written in such a way that playback can start after only a small
amount of the file is downloaded.

I think, 99.9% of use cases of this pod, is to capture video and upload it to s3 and later stream from network.
