### PR TITLE
Fix media writer failing to capture silent video

### DIFF
--- a/Source/PBJMediaWriter.m
+++ b/Source/PBJMediaWriter.m
@@ -70,9 +70,13 @@
         _outputURL = outputURL;
         _assetWriter.shouldOptimizeForNetworkUse = YES;
         _assetWriter.metadata = [self _metadataArray];
+
+        // It's possible to capture video without audio. If the user has denied access to the microphone, we don't need to setup the audio output device
+        if ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio] == AVAuthorizationStatusDenied) {
+            _audioReady = YES;
+        }
     }
     return self;
-
 }
 
 #pragma mark - private


### PR DESCRIPTION
If the user has denied microphone access, the media writer would never write any sample buffers so it's status would be AVAssetWriterStatusUnknown when `finishWritingWithCompletionHandler:` was called. This meant the `vision:capturedVideo:error:` delegate method would never be called.

Since it's valid to capture video without audio, this commit sets the `audioReady` state to YES if the user has denied microphone access. `captureOutput:didOutputSampleBuffer:fromConnection:` can then start passing video data to the writer without waiting for the audio output to be setup (which will never happen if the user has denied mic access)
