### PR TITLE
Let device pick its own frame rate ranges

### DIFF
--- a/Source/PBJVision.m
+++ b/Source/PBJVision.m
@@ -776,12 +776,6 @@ typedef void (^PBJVisionBlock)();
                 // smooth autofocus for videos
                 if ([newCaptureDevice isSmoothAutoFocusSupported])
                     [newCaptureDevice setSmoothAutoFocusEnabled:YES];
-
-                // setup framerate range
-                // TODO: seek best framerate range for slow-motion recording
-                CMTime frameDuration = CMTimeMake( 1, 30 );
-                newCaptureDevice.activeVideoMinFrameDuration = frameDuration;
-                newCaptureDevice.activeVideoMaxFrameDuration = frameDuration;
                 
                 [newCaptureDevice unlockForConfiguration];
         


### PR DESCRIPTION
I removed a segment of code that seemed to be arbitrarily picking a framerate range.

This was causing a crash that a previous version of PBJVision wasn't having an issue with. Not sure what introduced it, or whether it's a coincidence. 

[The docs warn of this particular crash](https://developer.apple.com/library/ios/documentation/AVFoundation/Reference/AVCaptureDevice_Class/Reference/Reference.html#//apple_ref/occ/instp/AVCaptureDevice/activeVideoMinFrameDuration), and it doesn't seem like this bit of code is necessary for any other functionality, as far as I can tell.
