### PR TITLE
Expose media writer's output URL

### DIFF
--- a/Source/PBJVision.h
+++ b/Source/PBJVision.h
@@ -127,6 +127,14 @@ extern NSString * const PBJVisionVideoThumbnailKey;
 @property (nonatomic) CGFloat videoBitRate;
 @property (nonatomic) NSInteger audioBitRate;
 
+/**
+ Returns the current output URL that the PBJMediaWriter is writing to.
+ 
+ Only returns a valid NSURL* if the PBJVision is currently recording.
+ If not, will return nil.
+ */
+@property (nonatomic, readonly) NSURL *mediaWriterOutputURL;
+
 // video frame rate (adjustment may change capture format (AVCaptureDeviceFormat : FoV, zoom factor, etc)
 
 @property (nonatomic) NSInteger videoFrameRate; // desire fps for cameraDevice

--- a/Source/PBJVision.m
+++ b/Source/PBJVision.m
@@ -218,6 +218,11 @@ typedef NS_ENUM(GLint, PBJVisionUniformLocationTypes)
     return _flags.videoRenderingEnabled;
 }
 
+- (NSURL *)mediaWriterOutputURL
+{
+    return self.isRecording ? _mediaWriter.outputURL : nil;
+}
+
 - (void)setThumbnailEnabled:(BOOL)thumbnailEnabled
 {
     _flags.thumbnailEnabled = (unsigned int)thumbnailEnabled;


### PR DESCRIPTION
This PR exposes the `PBJMediaWriter`'s output URL, so that clients of `PBJVision` can obtain the local file path that the video is being written to.
