### PR TITLE
Fixed Negative capturedVideoSeconds Bug

### DIFF
--- a/Source/PBJVision.m
+++ b/Source/PBJVision.m
@@ -240,6 +240,9 @@ typedef NS_ENUM(GLint, PBJVisionUniformLocationTypes)
 - (Float64)capturedVideoSeconds
 {
     if (_mediaWriter && CMTIME_IS_VALID(_mediaWriter.videoTimestamp)) {
+        if (CMTimeGetSeconds(CMTimeSubtract(_mediaWriter.videoTimestamp, _startTimestamp)) < 0) {
+            _startTimestamp = _mediaWriter.videoTimestamp;
+        }
         return CMTimeGetSeconds(CMTimeSubtract(_mediaWriter.videoTimestamp, _startTimestamp));
     } else {
         return 0.0;


### PR DESCRIPTION
In PBJVision.m, I added an if statement to handle situations where the method capturedVideoSeconds was returning a negative value.
This situation had prevented my multi-view application from recognizing that new video was being captured on a return visit to a view that recorded video.
