### PR TITLE
Check if DLog is defined before defining it to avoid warnings/conflicts

### DIFF
--- a/Source/PBJVision.m
+++ b/Source/PBJVision.m
@@ -33,10 +33,12 @@
 #import <OpenGLES/EAGL.h>
 
 #define LOG_VISION 0
+#ifndef DLog
 #if !defined(NDEBUG) && LOG_VISION
 #   define DLog(fmt, ...) NSLog((@"VISION: " fmt), ##__VA_ARGS__);
 #else
 #   define DLog(...)
+#endif
 #endif
 
 NSString * const PBJVisionErrorDomain = @"PBJVisionErrorDomain";


### PR DESCRIPTION
@piemonte I know you said you prefer PRs with several commits, let me know if for something like this I should just open up an issue instead? Basically I've already got DLog defined in my project (and I'm sure others do too). This would just avoid the 'redefinition' warning. However it relies on the understanding of what DLog is and if someone implemented DLog in an unexpected fashion it could cause issues?
