### PR TITLE
Added Captured video duration metadata when video is saved

### DIFF
--- a/Source/PBJVision.h
+++ b/Source/PBJVision.h
@@ -96,6 +96,7 @@ extern NSString * const PBJVisionPhotoThumbnailKey; // 160x120
 
 extern NSString * const PBJVisionVideoPathKey;
 extern NSString * const PBJVisionVideoThumbnailKey;
+extern NSString * const PBJVisionVideoCapturedDurationKey; // Captured duration in seconds
 
 @class EAGLContext;
 @protocol PBJVisionDelegate;

--- a/Source/PBJVision.m
+++ b/Source/PBJVision.m
@@ -66,6 +66,8 @@ NSString * const PBJVisionPhotoThumbnailKey = @"PBJVisionPhotoThumbnailKey";
 
 NSString * const PBJVisionVideoPathKey = @"PBJVisionVideoPathKey";
 NSString * const PBJVisionVideoThumbnailKey = @"PBJVisionVideoThumbnailKey";
+NSString * const PBJVisionVideoCapturedDurationKey = @"PBJVisionVideoCapturedDurationKey";
+
 
 // PBJGLProgram shader uniforms for pixel format conversion on the GPU
 typedef NS_ENUM(GLint, PBJVisionUniformLocationTypes)
@@ -1640,6 +1642,8 @@ typedef void (^PBJVisionBlock)();
         _flags.paused = NO;
         
         void (^finishWritingCompletionHandler)(void) = ^{
+            Float64 capturedDuration = self.capturedVideoSeconds;
+            
             _lastTimestamp = kCMTimeInvalid;
             _startTimestamp = CMClockGetTime(CMClockGetHostTimeClock());
             _flags.interrupted = NO;
@@ -1649,6 +1653,8 @@ typedef void (^PBJVisionBlock)();
                 NSString *path = [_mediaWriter.outputURL path];
                 if (path)
                     [videoDict setObject:path forKey:PBJVisionVideoPathKey];
+
+                [videoDict setObject:@(capturedDuration) forKey:PBJVisionVideoCapturedDurationKey];
 
                 NSError *error = [_mediaWriter error];
                 if ([_delegate respondsToSelector:@selector(vision:capturedVideo:error:)]) {


### PR DESCRIPTION
It's done  because at the moment, when video is done recording there's no other way to get it's duration
Useful when you have some restrictions on the minimum recorded video duration
