### PR TITLE
Video profile level added to  for video output customisation

### DIFF
--- a/Source/PBJVision.h
+++ b/Source/PBJVision.h
@@ -122,10 +122,19 @@ extern NSString * const PBJVisionVideoCapturedDurationKey; // Captured duration 
 
 // video output/compression settings
 
-@property (nonatomic, strong) NSString *captureSessionPreset;
+@property (nonatomic, copy) NSString *captureSessionPreset;
 @property (nonatomic) PBJOutputFormat outputFormat;
 @property (nonatomic) CGFloat videoBitRate;
 @property (nonatomic) NSInteger audioBitRate;
+@property (nonatomic, copy) NSString *videoProfileLevel; // @see AVVideoProfileLevelKey. Default value is AVVideoProfileLevelH264Baseline30
+
+// Video output custom settings
+// Setting this property will disable any passes in values of outputFormat, videoBitRate, audioBitRate, videoProfileLevel
+// These settings will be passed directly to the Asset Writer via
+// [[AVAssetWriterInput alloc] initWithMediaType:AVMediaTypeVideo outputSettings:videoOutputSettings]
+// Default value is nil
+@property (nonatomic, strong) NSDictionary *videoOutputSettings;
+
 
 // video frame rate (adjustment may change the capture format (AVCaptureDeviceFormat : FoV, zoom factor, etc)
 

--- a/Source/PBJVision.m
+++ b/Source/PBJVision.m
@@ -180,6 +180,8 @@ typedef NS_ENUM(GLint, PBJVisionUniformLocationTypes)
 @synthesize presentationFrame = _presentationFrame;
 @synthesize audioBitRate = _audioBitRate;
 @synthesize videoBitRate = _videoBitRate;
+@synthesize videoProfileLevel = _videoProfileLevel;
+@synthesize videoOutputSettings = _videoOutputSettings;
 @synthesize captureSessionPreset = _captureSessionPreset;
 @synthesize maximumCaptureDuration = _maximumCaptureDuration;
 
@@ -646,6 +648,9 @@ typedef NS_ENUM(GLint, PBJVisionUniformLocationTypes)
         // 5000000, good for iFrame 1280 x 720
         CGFloat bytesPerSecond = 437500;
         _videoBitRate = bytesPerSecond * 8;
+
+        // Video profile for video compression
+        _videoProfileLevel = AVVideoProfileLevelH264Baseline30;
         
         // default flags
         _flags.thumbnailEnabled = YES;
@@ -1722,6 +1727,11 @@ typedef void (^PBJVisionBlock)();
 
 - (BOOL)_setupMediaWriterVideoInputWithSampleBuffer:(CMSampleBufferRef)sampleBuffer
 {
+    // Use the custom output settings, in case of some specific video settings
+    if (_videoOutputSettings) {
+        return [_mediaWriter setupVideoOutputDeviceWithSettings:_videoOutputSettings];
+    }
+
     CMFormatDescriptionRef formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer);
 	CMVideoDimensions dimensions = CMVideoFormatDescriptionGetDimensions(formatDescription);
     
@@ -1746,7 +1756,7 @@ typedef void (^PBJVisionBlock)();
     }
     
     // TODO: expose a means for adding addition options to setings
-    NSDictionary *compressionSettings = @{ AVVideoProfileLevelKey : AVVideoProfileLevelH264Baseline30,
+    NSDictionary *compressionSettings = @{ AVVideoProfileLevelKey : _videoProfileLevel,
                                            AVVideoAverageBitRateKey : @(_videoBitRate),
                                            AVVideoMaxKeyFrameIntervalKey : @(_videoFrameRate) };
 


### PR DESCRIPTION
Added videoOutputSettings - for the ability to pass any possible video settings to the asset writer
Update that will allow to fix situations, described in #138
