### PR TITLE
Fix for maximum capture duration

### DIFF
--- a/Source/PBJVision.m
+++ b/Source/PBJVision.m
@@ -1883,7 +1883,7 @@ typedef void (^PBJVisionBlock)();
         
         currentTimestamp = CMSampleBufferGetPresentationTimeStamp(sampleBuffer);
         
-        if (CMTIME_IS_VALID(currentTimestamp) && CMTIME_IS_VALID(_startTimestamp) && CMTIME_IS_VALID(_maximumCaptureDuration)) {
+        if (!_flags.interrupted && CMTIME_IS_VALID(currentTimestamp) && CMTIME_IS_VALID(_startTimestamp) && CMTIME_IS_VALID(_maximumCaptureDuration)) {
             
             if (CMTIME_IS_VALID(_lastTimestamp)) {
                 // Current time stamp is actually timstamp with data from globalClock


### PR DESCRIPTION
This update will fix maximum capture duration logic (again):)  
Tested with long recording time up to maximumCaptureDuration  
And with lot of small pause/resume iterations

**NOTE** It'll be good to rename `_lastTimeStamp` to `_offsetFromGlobalClock` or something like this  
Because there's not actually timestamps in the `_lastTimeStamp` variable
