### PR TITLE
Created a property for bytesPerSecond and changed the way videoBitRate is set

### DIFF
--- a/Source/PBJVision.h
+++ b/Source/PBJVision.h
@@ -75,6 +75,17 @@ typedef NS_ENUM(NSInteger, PBJOutputFormat) {
     PBJOutputFormatWidescreen
 };
 
+
+//bytesPerSecond defined from those in the PBJVision.m
+typedef NS_ENUM(NSInteger, PBJBytesPerSecond) {
+    PBJBytesPerSecond480X360 = 87500,
+    PBJBytesPerSecond640X480 = 437500,
+    PBJBytesPerSecond1280X720 = 1312500,
+    PBJBytesPerSecond1920X1080 = 2975000,
+    PBJBytesPerSecond960X540 = 3750000,
+    PBJBytesPerSecond1280X750 = 5000000
+};
+
 // PBJError
 
 extern NSString * const PBJVisionErrorDomain;
@@ -129,6 +140,9 @@ extern NSString * const PBJVisionVideoCapturedDurationKey; // Captured duration 
 
 @property (nonatomic) CGFloat videoBitRate;
 @property (nonatomic) NSInteger audioBitRate;
+
+//Whenever this is set it updates the videoBitRate
+@property (nonatomic) CGFloat bytesPerSecond;
 
 // video frame rate (adjustment may change the capture format (AVCaptureDeviceFormat : FoV, zoom factor, etc)
 

--- a/Source/PBJVision.m
+++ b/Source/PBJVision.m
@@ -182,6 +182,7 @@ typedef NS_ENUM(GLint, PBJVisionUniformLocationTypes)
 @synthesize videoBitRate = _videoBitRate;
 @synthesize captureSessionPreset = _captureSessionPreset;
 @synthesize maximumCaptureDuration = _maximumCaptureDuration;
+@synthesize bytesPerSecond = _bytesPerSecond;
 
 #pragma mark - singleton
 
@@ -644,8 +645,8 @@ typedef NS_ENUM(GLint, PBJVisionUniformLocationTypes)
         // 2975000, good for 1920 x 1080
         // 3750000, good for iFrame 960 x 540
         // 5000000, good for iFrame 1280 x 720
-        CGFloat bytesPerSecond = 437500;
-        _videoBitRate = bytesPerSecond * 8;
+        _bytesPerSecond = 437500;
+//        _videoBitRate = _bytesPerSecond * 8;
         
         // default flags
         _flags.thumbnailEnabled = YES;
@@ -662,6 +663,11 @@ typedef NS_ENUM(GLint, PBJVisionUniformLocationTypes)
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_applicationDidEnterBackground:) name:@"UIApplicationDidEnterBackgroundNotification" object:[UIApplication sharedApplication]];
     }
     return self;
+}
+
+- (void)setBytesPerSecond:(CGFloat)bytesPerSecond {
+    bytesPerSecond = _bytesPerSecond;
+    _videoBitRate = bytesPerSecond * 8;
 }
 
 - (void)dealloc


### PR DESCRIPTION
Added the bytesPerSecond property in the .h file. 
Set bytesPerSecond in the .m such that when it is set, it also makes sure that the videoBitRate changes to “bytesPerSecond \* 8.” 
Changed the suggested bytesPerSecond defined in the .m file to an ENUM so that someone can call the descriptive name (PBJBytesPerSecond480X360) rather than a number (87500).

These make it easier to use in code (one doesn't have to remember to multiple by 8, reduces errors with copying numbers, makes code easier to read by descriptive names, etc). 
