### PR TITLE
added new flag to disable audio capture

### DIFF
--- a/Source/PBJVision.h
+++ b/Source/PBJVision.h
@@ -186,6 +186,8 @@ static CGFloat const PBJVideoBitRate1280x750 = 5000000 * 8;
 @property (nonatomic, readonly, getter=isPaused) BOOL paused;
 
 @property (nonatomic, getter=isVideoRenderingEnabled) BOOL videoRenderingEnabled;
+@property (nonatomic, getter=isAudioCaptureEnabled) BOOL audioCaptureEnabled;
+
 @property (nonatomic, readonly) EAGLContext *context;
 @property (nonatomic) CGRect presentationFrame;
 


### PR DESCRIPTION
Needed the ability to record video without audio, so I made a quick change to support it by adding a new flag, audioCaptureEnabled (following coding style appropriately using videoRenderingEnabled as a model).

Setting audioCaptureEnabled to NO (default is YES) will disable audio capture for video.

I also made changes to properly handle the error handling for audio when disabled and to handle the switch mode case correctly. Tested changes with the test app on two devices.
