### PR TITLE
Added support for separate previewOrientation

### DIFF
--- a/Source/PBJVisionUtilities.m
+++ b/Source/PBJVisionUtilities.m
@@ -33,7 +33,7 @@
     CGPoint pointOfInterest = CGPointMake(.5f, .5f);
     CGSize frameSize = frame.size;
     
-    switch ([[PBJVision sharedInstance] cameraOrientation]) {
+    switch ([[PBJVision sharedInstance] previewOrientation]) {
         case PBJCameraOrientationPortrait:
             break;
         case PBJCameraOrientationPortraitUpsideDown:


### PR DESCRIPTION
I updated the `convertToPointOfInterestFromViewCoordinates:` method to use the new `previewOrientation` property. This is a follow up on: https://github.com/piemonte/PBJVision/pull/157
