### PR TITLE
Better support for orientations

### DIFF
--- a/Project/Vision.xcodeproj/project.pbxproj
+++ b/Project/Vision.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		06DF60731896B535000870C9 /* PBJMediaWriter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PBJMediaWriter.m; path = ../Source/PBJMediaWriter.m; sourceTree = "<group>"; };
 		06FEB59D18F5C15600AFD4DB /* PBJGLProgram.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PBJGLProgram.h; path = ../Source/PBJGLProgram.h; sourceTree = "<group>"; };
 		06FEB59E18F5C15600AFD4DB /* PBJGLProgram.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PBJGLProgram.m; path = ../Source/PBJGLProgram.m; sourceTree = "<group>"; };
+		D313E429195DB44D00A411E1 /* PBJVisionTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PBJVisionTypes.h; path = ../Source/PBJVisionTypes.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -221,6 +222,7 @@
 			isa = PBXGroup;
 			children = (
 				06FEB5A018F5C16400AFD4DB /* Effects */,
+				D313E429195DB44D00A411E1 /* PBJVisionTypes.h */,
 				06B7D01A179F2E7700F3F527 /* PBJVision.h */,
 				06B7D01B179F2E7700F3F527 /* PBJVision.m */,
 				06B7D01C179F2E7700F3F527 /* PBJVisionUtilities.h */,

--- a/Source/PBJVision.h
+++ b/Source/PBJVision.h
@@ -25,62 +25,7 @@
 
 #import <Foundation/Foundation.h>
 #import <AVFoundation/AVFoundation.h>
-
-// vision types
-
-typedef NS_ENUM(NSInteger, PBJCameraDevice) {
-    PBJCameraDeviceBack = UIImagePickerControllerCameraDeviceRear,
-    PBJCameraDeviceFront = UIImagePickerControllerCameraDeviceFront
-};
-
-typedef NS_ENUM(NSInteger, PBJCameraMode) {
-    PBJCameraModePhoto = UIImagePickerControllerCameraCaptureModePhoto,
-    PBJCameraModeVideo = UIImagePickerControllerCameraCaptureModeVideo
-};
-
-typedef NS_ENUM(NSInteger, PBJCameraOrientation) {
-    PBJCameraOrientationPortrait = AVCaptureVideoOrientationPortrait,
-    PBJCameraOrientationPortraitUpsideDown = AVCaptureVideoOrientationPortraitUpsideDown,
-    PBJCameraOrientationLandscapeRight = AVCaptureVideoOrientationLandscapeRight,
-    PBJCameraOrientationLandscapeLeft = AVCaptureVideoOrientationLandscapeLeft,
-};
-
-typedef NS_ENUM(NSInteger, PBJFocusMode) {
-    PBJFocusModeLocked = AVCaptureFocusModeLocked,
-    PBJFocusModeAutoFocus = AVCaptureFocusModeAutoFocus,
-    PBJFocusModeContinuousAutoFocus = AVCaptureFocusModeContinuousAutoFocus
-};
-
-typedef NS_ENUM(NSInteger, PBJExposureMode) {
-    PBJExposureModeLocked = AVCaptureExposureModeLocked,
-    PBJExposureModeAutoExpose = AVCaptureExposureModeAutoExpose,
-    PBJExposureModeContinuousAutoExposure = AVCaptureExposureModeContinuousAutoExposure
-};
-
-typedef NS_ENUM(NSInteger, PBJFlashMode) {
-    PBJFlashModeOff  = AVCaptureFlashModeOff,
-    PBJFlashModeOn   = AVCaptureFlashModeOn,
-    PBJFlashModeAuto = AVCaptureFlashModeAuto
-};
-
-typedef NS_ENUM(NSInteger, PBJMirroringMode) {
-	PBJMirroringAuto,
-	PBJMirroringOn,
-	PBJMirroringOff
-};
-
-typedef NS_ENUM(NSInteger, PBJAuthorizationStatus) {
-    PBJAuthorizationStatusNotDetermined = 0,
-    PBJAuthorizationStatusAuthorized,
-    PBJAuthorizationStatusAudioDenied
-};
-
-typedef NS_ENUM(NSInteger, PBJOutputFormat) {
-    PBJOutputFormatPreset = 0,
-    PBJOutputFormatSquare,
-    PBJOutputFormatWidescreen,
-    PBJOutputFormatStandard /* 4:3 */
-};
+#import "PBJVisionTypes.h"
 
 // PBJError
 

--- a/Source/PBJVision.m
+++ b/Source/PBJVision.m
@@ -293,33 +293,19 @@ typedef NS_ENUM(GLint, PBJVisionUniformLocationTypes)
         return;
 
     if ([_previewLayer.connection isVideoOrientationSupported]) {
+        AVCaptureVideoOrientation convertedOrientation = [PBJVisionUtilities convertToCaptureVideoOrientationFromCameraOrientation:previewOrientation];
+        [_previewLayer.connection setVideoOrientation:convertedOrientation];
         _previewOrientation = previewOrientation;
-        [self _setOrientationForConnection:_previewLayer.connection];
     }
 }
+
 
 - (void)_setOrientationForConnection:(AVCaptureConnection *)connection
 {
     if (!connection || ![connection isVideoOrientationSupported])
         return;
 
-    AVCaptureVideoOrientation orientation = AVCaptureVideoOrientationPortrait;
-    switch (_cameraOrientation) {
-        case PBJCameraOrientationPortraitUpsideDown:
-            orientation = AVCaptureVideoOrientationPortraitUpsideDown;
-            break;
-        case PBJCameraOrientationLandscapeRight:
-            orientation = AVCaptureVideoOrientationLandscapeRight;
-            break;
-        case PBJCameraOrientationLandscapeLeft:
-            orientation = AVCaptureVideoOrientationLandscapeLeft;
-            break;
-        default:
-        case PBJCameraOrientationPortrait:
-            orientation = AVCaptureVideoOrientationPortrait;
-            break;
-    }
-
+    AVCaptureVideoOrientation orientation = [PBJVisionUtilities convertToCaptureVideoOrientationFromCameraOrientation:_cameraOrientation];
     [connection setVideoOrientation:orientation];
 }
 
@@ -1156,7 +1142,9 @@ typedef void (^PBJVisionBlock)();
     
         if (_previewLayer && _previewLayer.session != _captureSession) {
             _previewLayer.session = _captureSession;
-            [self _setOrientationForConnection:_previewLayer.connection];
+            if (self.autoUpdatePreviewOrientation) {
+                [self setPreviewOrientation:_cameraOrientation];
+            }
         }
         
         if (![_captureSession isRunning]) {

--- a/Source/PBJVisionTypes.h
+++ b/Source/PBJVisionTypes.h
@@ -1,0 +1,85 @@
+//
+//  PBJVisionTypes.h
+//  Vision
+//
+//  Created by Patrick Piemonte on 4/30/13.
+//  Copyright (c) 2013-present, Patrick Piemonte, http://patrickpiemonte.com
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of
+//  this software and associated documentation files (the "Software"), to deal in
+//  the Software without restriction, including without limitation the rights to
+//  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+//  the Software, and to permit persons to whom the Software is furnished to do so,
+//  subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+//  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+//  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+//  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#ifndef Vision_PBJVisionTypes_h
+#define Vision_PBJVisionTypes_h
+
+// vision types
+
+typedef NS_ENUM(NSInteger, PBJCameraDevice) {
+    PBJCameraDeviceBack = UIImagePickerControllerCameraDeviceRear,
+    PBJCameraDeviceFront = UIImagePickerControllerCameraDeviceFront
+};
+
+typedef NS_ENUM(NSInteger, PBJCameraMode) {
+    PBJCameraModePhoto = UIImagePickerControllerCameraCaptureModePhoto,
+    PBJCameraModeVideo = UIImagePickerControllerCameraCaptureModeVideo
+};
+
+typedef NS_ENUM(NSInteger, PBJCameraOrientation) {
+    PBJCameraOrientationPortrait = AVCaptureVideoOrientationPortrait,
+    PBJCameraOrientationPortraitUpsideDown = AVCaptureVideoOrientationPortraitUpsideDown,
+    PBJCameraOrientationLandscapeRight = AVCaptureVideoOrientationLandscapeRight,
+    PBJCameraOrientationLandscapeLeft = AVCaptureVideoOrientationLandscapeLeft,
+};
+
+typedef NS_ENUM(NSInteger, PBJFocusMode) {
+    PBJFocusModeLocked = AVCaptureFocusModeLocked,
+    PBJFocusModeAutoFocus = AVCaptureFocusModeAutoFocus,
+    PBJFocusModeContinuousAutoFocus = AVCaptureFocusModeContinuousAutoFocus
+};
+
+typedef NS_ENUM(NSInteger, PBJExposureMode) {
+    PBJExposureModeLocked = AVCaptureExposureModeLocked,
+    PBJExposureModeAutoExpose = AVCaptureExposureModeAutoExpose,
+    PBJExposureModeContinuousAutoExposure = AVCaptureExposureModeContinuousAutoExposure
+};
+
+typedef NS_ENUM(NSInteger, PBJFlashMode) {
+    PBJFlashModeOff  = AVCaptureFlashModeOff,
+    PBJFlashModeOn   = AVCaptureFlashModeOn,
+    PBJFlashModeAuto = AVCaptureFlashModeAuto
+};
+
+typedef NS_ENUM(NSInteger, PBJMirroringMode) {
+	PBJMirroringAuto,
+	PBJMirroringOn,
+	PBJMirroringOff
+};
+
+typedef NS_ENUM(NSInteger, PBJAuthorizationStatus) {
+    PBJAuthorizationStatusNotDetermined = 0,
+    PBJAuthorizationStatusAuthorized,
+    PBJAuthorizationStatusAudioDenied
+};
+
+typedef NS_ENUM(NSInteger, PBJOutputFormat) {
+    PBJOutputFormatPreset = 0,
+    PBJOutputFormatSquare,
+    PBJOutputFormatWidescreen,
+    PBJOutputFormatStandard /* 4:3 */
+};
+
+#endif

--- a/Source/PBJVisionUtilities.h
+++ b/Source/PBJVisionUtilities.h
@@ -25,6 +25,7 @@
 
 #import <Foundation/Foundation.h>
 #import <AVFoundation/AVFoundation.h>
+#import "PBJVisionTypes.h"
 
 @interface PBJVisionUtilities : NSObject
 
@@ -38,6 +39,9 @@
 + (CMSampleBufferRef)createOffsetSampleBufferWithSampleBuffer:(CMSampleBufferRef)sampleBuffer usingTimeOffset:(CMTime)timeOffset;
 
 + (CGFloat)angleOffsetFromPortraitOrientationToOrientation:(AVCaptureVideoOrientation)orientation;
+
++ (AVCaptureVideoOrientation)convertToCaptureVideoOrientationFromCameraOrientation:(PBJCameraOrientation)cameraOrientation;
++ (PBJCameraOrientation)convertToCameraOrientationFromDeviceOrientation:(UIDeviceOrientation)deviceOrientation;
 
 + (uint64_t)availableDiskSpaceInBytes;
 

--- a/Source/PBJVisionUtilities.m
+++ b/Source/PBJVisionUtilities.m
@@ -197,6 +197,52 @@
 	return angle;
 }
 
++ (AVCaptureVideoOrientation)convertToCaptureVideoOrientationFromCameraOrientation:(PBJCameraOrientation)cameraOrientation {
+    AVCaptureVideoOrientation orientation = AVCaptureVideoOrientationPortrait;
+
+    switch (cameraOrientation) {
+        case PBJCameraOrientationPortraitUpsideDown:
+            orientation = AVCaptureVideoOrientationPortraitUpsideDown;
+            break;
+        case PBJCameraOrientationLandscapeRight:
+            orientation = AVCaptureVideoOrientationLandscapeRight;
+            break;
+        case PBJCameraOrientationLandscapeLeft:
+            orientation = AVCaptureVideoOrientationLandscapeLeft;
+            break;
+        default:
+        case PBJCameraOrientationPortrait:
+            orientation = AVCaptureVideoOrientationPortrait;
+            break;
+    }
+
+    return orientation;
+}
+
++ (PBJCameraOrientation)convertToCameraOrientationFromDeviceOrientation:(UIDeviceOrientation)deviceOrientation {
+    PBJCameraOrientation orientation = PBJCameraOrientationPortrait;
+    
+    switch (deviceOrientation) {
+        case UIDeviceOrientationPortrait:
+            orientation = PBJCameraOrientationPortrait;
+            break;
+            
+        case UIDeviceOrientationLandscapeLeft:
+            orientation = PBJCameraOrientationLandscapeRight;
+            break;
+            
+        case UIDeviceOrientationLandscapeRight:
+            orientation = PBJCameraOrientationLandscapeLeft;
+            break;
+            
+        default:
+            orientation = PBJCameraOrientationPortrait;
+            break;
+    }
+    
+    return orientation;
+}
+
 #pragma mark - memory
 
 + (uint64_t)availableDiskSpaceInBytes


### PR DESCRIPTION
I keep finding little pieces of orientation related code that should have been updated along with https://github.com/piemonte/PBJVision/pull/157 and https://github.com/piemonte/PBJVision/pull/158.

This pull request fixes the setup of preview orientation in the `startPreview` method along with some other parts I initially missed.

To decrease code duplication I added two methods to the utilities class. These convert orientations from `PBJCameraOrientation` to `AVCaptureVideoOrientation` and from `UIDeviceOrientation` to `PBJCameraOrientation`. For this, the enums had to be moved into their own header (`PBJVisionTypes.h`).

I do not have full insight in the code for this project, so maybe someone else can check this pull request to make sure I didn't miss anything this time.
