### PR TITLE
Remove observer on _captureOutputPhoto during dealloc

### DIFF
--- a/Source/PBJVision.m
+++ b/Source/PBJVision.m
@@ -894,6 +894,8 @@ typedef void (^PBJVisionBlock)();
     // capture device notifications
     [notificationCenter removeObserver:self name:AVCaptureDeviceSubjectAreaDidChangeNotification object:nil];
 
+    [_captureOutputPhoto removeObserver:self forKeyPath:@"capturingStillImage"];
+
     _captureOutputPhoto = nil;
     _captureOutputAudio = nil;
     _captureOutputVideo = nil;


### PR DESCRIPTION
I got a bug report that looks like the missing removal here leads to a possible exception during camera destruction.  Here's what I saw:

```
An instance 0x17003b5e0 of class AVCaptureStillImageOutput was deallocated while key value observers were still registered with it. Current observation info: <NSKeyValueObservationInfo 0x178a48e50> ( <NSKeyValueObservance 0x1700d46d0: Observer: 0x12655a010, Key path: capturingStillImage, Options: <New: YES, Old: NO, Prior: NO> Context: 0x100412bd0, Property: 0x1702503e0>
```

It's worth noting that I only got one crash report for this, and it was from a 6 Plus.
