### PR TITLE
added visionDidEndVideoCapture delegate

### DIFF
--- a/Source/PBJVision.h
+++ b/Source/PBJVision.h
@@ -285,6 +285,7 @@ static CGFloat const PBJVideoBitRate1280x750 = 5000000 * 8;
 - (void)visionDidStartVideoCapture:(PBJVision *)vision;
 - (void)visionDidPauseVideoCapture:(PBJVision *)vision; // stopped but not ended
 - (void)visionDidResumeVideoCapture:(PBJVision *)vision;
+- (void)visionDidEndVideoCapture:(PBJVision *)vision;
 - (void)vision:(PBJVision *)vision capturedVideo:(NSDictionary *)videoDict error:(NSError *)error;
 
 // video capture progress

--- a/Source/PBJVision.m
+++ b/Source/PBJVision.m
@@ -1805,6 +1805,9 @@ typedef void (^PBJVisionBlock)();
             _flags.interrupted = NO;
 
             [self _enqueueBlockOnMainQueue:^{
+                if ([_delegate respondsToSelector:@selector(visionDidEndVideoCapture:)])
+                    [_delegate visionDidEndVideoCapture:self];
+
                 NSMutableDictionary *videoDict = [[NSMutableDictionary alloc] init];
                 NSString *path = [_mediaWriter.outputURL path];
                 if (path) {


### PR DESCRIPTION
This allows the caller to capture thumbnails (especially those
dependent on captured video length) immediately prior to creation of
the the video dictionary.
