### PR TITLE
Setup mirroring after session configuration so output respects mirror setting

### DIFF
--- a/Source/PBJVision.m
+++ b/Source/PBJVision.m
@@ -385,8 +385,6 @@ typedef NS_ENUM(GLint, PBJVisionUniformLocationTypes)
     _cameraDevice = cameraDevice;
     _cameraMode = cameraMode;
     
-    [self setMirroringMode:_mirroringMode];
-
     _outputFormat = outputFormat;
     
     // since there is no session in progress, set and bail
@@ -409,6 +407,8 @@ typedef NS_ENUM(GLint, PBJVisionUniformLocationTypes)
     [self _enqueueBlockOnCaptureSessionQueue:^{
         // camera is already setup, no need to call _setupCamera
         [self _setupSession];
+
+        [self setMirroringMode:_mirroringMode];
         
         [self _enqueueBlockOnMainQueue:^{
             _flags.changingModes = NO;
@@ -1184,6 +1184,8 @@ typedef void (^PBJVisionBlock)();
             [self _setupCamera];
             [self _setupSession];
         }
+
+        [self setMirroringMode:_mirroringMode];
     
         if (_previewLayer && _previewLayer.session != _captureSession) {
             _previewLayer.session = _captureSession;


### PR DESCRIPTION
There's an apparent bug where if you use mirroring (usually for the front-facing camera), the output is mirrored correctly on the preview layer but not in the actual capture (for both photo and video). The issue stems from replacing the output during _setupSession without re-running the mirror setup code, so if you're switching devices or just using the auto-mirror mode you can end up with a busted output. This change should resolve the issues.
