### PR TITLE
changing session presset at runtime

### DIFF
--- a/Source/PBJVision.m
+++ b/Source/PBJVision.m
@@ -431,6 +431,16 @@ typedef NS_ENUM(GLint, PBJVisionUniformLocationTypes)
     [self _setCameraMode:_cameraMode cameraDevice:cameraDevice outputFormat:_outputFormat];
 }
 
+- (void) setCaptureSessionPreset:(NSString *)captureSessionPreset
+{
+    _captureSessionPreset = captureSessionPreset;
+    if ([_captureSession canSetSessionPreset:captureSessionPreset]){
+        [self _commitBlock:^{
+            [_captureSession setSessionPreset:captureSessionPreset];
+        }];
+    }
+}
+
 - (void)setCameraMode:(PBJCameraMode)cameraMode
 {
     [self _setCameraMode:cameraMode cameraDevice:_cameraDevice outputFormat:_outputFormat];
@@ -771,6 +781,13 @@ typedef void (^PBJVisionBlock)();
     dispatch_sync(dispatch_get_main_queue(), ^{
         block();
     });
+}
+
+- (void) _commitBlock:(void(^)())block
+{
+    [_captureSession beginConfiguration];
+    block();
+    [_captureSession commitConfiguration];
 }
 
 #pragma mark - camera


### PR DESCRIPTION
Hey, I had an issue setting up PBJVision in the example project. My basic configuration of PBJVision singleton class was the following inside of _resetCapture method:

```
vision.cameraMode = PBJCameraModeVideo;
vision.cameraOrientation = PBJCameraOrientationLandscapeLeft;
vision.focusMode = PBJFocusModeContinuousAutoFocus;
vision.captureSessionPreset = AVCaptureSessionPreset1920x1080;
vision.videoRenderingEnabled = YES;
vision.additionalCompressionProperties = @{AVVideoProfileLevelKey : AVVideoProfileLevelH264Baseline41}; // AVVideoProfileLevelKey requires specific captureSessionPreset
```

So when I try to flip the camera, the preview layer stop working:
- (void)_handleFlipButton:(UIButton *)button
  {
  PBJVision *vision = [PBJVision sharedInstance];
  vision.additionalCompressionProperties = @{AVVideoProfileLevelKey : AVVideoProfileLevelH264Baseline30}; // AVVideoProfileLevelKey requires specific captureSessionPreset
  vision.captureSessionPreset = AVCaptureSessionPresetMedium;
  vision.cameraDevice = vision.cameraDevice == PBJCameraDeviceBack ? PBJCameraDeviceFront : PBJCameraDeviceBack;
  }

So, to fix this issue I had to update the value of sessionPreset property of _captureSession object.
