### PR TITLE
startPreview enables connection

### DIFF
--- a/Source/PBJVision.m
+++ b/Source/PBJVision.m
@@ -1209,6 +1209,9 @@ typedef void (^PBJVisionBlock)();
             [self _setOrientationForConnection:_previewLayer.connection];
         }
         
+        if (_previewLayer)
+            _previewLayer.connection.enabled = YES;
+        
         if (![_captureSession isRunning]) {
             [_captureSession startRunning];
             


### PR DESCRIPTION
The last merge broke apps that toggle between startPreview and
stopPreview because the connection is explicitly disabled (in stop) and
never explicitly enabled (in start).