### PR TITLE
example/proposed changes for use with Swift 1.2

### DIFF
--- a/Source/PBJVision.h
+++ b/Source/PBJVision.h
@@ -26,6 +26,15 @@
 #import <Foundation/Foundation.h>
 #import <AVFoundation/AVFoundation.h>
 
+// support for swift compiler
+#ifndef NS_ASSUME_NONNULL_BEGIN
+# define NS_ASSUME_NONNULL_BEGIN
+# define nullable
+# define NS_ASSUME_NONNULL_END
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
 // vision types
 
 typedef NS_ENUM(NSInteger, PBJCameraDevice) {
@@ -292,11 +301,13 @@ static CGFloat const PBJVideoBitRate1280x750 = 5000000 * 8;
 - (void)visionDidPauseVideoCapture:(PBJVision *)vision; // stopped but not ended
 - (void)visionDidResumeVideoCapture:(PBJVision *)vision;
 - (void)visionDidEndVideoCapture:(PBJVision *)vision;
-- (void)vision:(PBJVision *)vision capturedVideo:(NSDictionary *)videoDict error:(NSError *)error;
+- (void)vision:(PBJVision *)vision capturedVideo:(nullable NSDictionary *)videoDict error:(nullable NSError *)error;
 
 // video capture progress
 
 - (void)vision:(PBJVision *)vision didCaptureVideoSampleBuffer:(CMSampleBufferRef)sampleBuffer;
 - (void)vision:(PBJVision *)vision didCaptureAudioSample:(CMSampleBufferRef)sampleBuffer;
+
+NS_ASSUME_NONNULL_END
 
 @end


### PR DESCRIPTION
I'm using the PBJVision code in a Swift app. The newest Xcode beta allows for making sure method signatures are more accurate when defined in Swift code; there may be other/different changes here but the code compile correctly with the current release Xcode 6.1 as well as Beta 4.  If not these changes, perhaps something similar. Cheers