### PR TITLE
Allow the delegate to be set to nil from Swift 1.2

### DIFF
--- a/Source/PBJVision.h
+++ b/Source/PBJVision.h
@@ -134,7 +134,7 @@ static CGFloat const PBJVideoBitRate1280x750 = 5000000 * 8;
 
 + (PBJVision *)sharedInstance;
 
-@property (nonatomic, weak) id<PBJVisionDelegate> delegate;
+@property (nonatomic, weak, nullable) id<PBJVisionDelegate> delegate;
 
 // session
 


### PR DESCRIPTION
This micro-change just allows the delegate to be set to nil in Swift 1.2 - without it, trying to unset the delegate is rejected by the compiler.

Without this change I run into this issue:

![image](https://cloud.githubusercontent.com/assets/230271/7378892/c0bc338a-edbe-11e4-99d3-2ca6d6f71366.png)

This continues the work started by @msjulie in 0f8fd0732c13969d0d54b2fab5d79ce065a924f2 (#236)

Thanks for a fantastic library!