### PR TITLE
_exposureMode and _focusMode aren't initialized

### DIFF
--- a/Source/PBJVision.m
+++ b/Source/PBJVision.m
@@ -500,6 +500,13 @@ typedef NS_ENUM(GLint, PBJVisionUniformLocationTypes)
 
 }
 
+- (void) _setCurrentDevice:(AVCaptureDevice *)device
+{
+    _currentDevice  = device;
+    _exposureMode   = (PBJExposureMode)device.exposureMode;
+    _focusMode      = (PBJFocusMode)device.focusMode;
+}
+
 - (BOOL)isFlashAvailable
 {
     return (_currentDevice && [_currentDevice hasFlash]);
@@ -1128,7 +1135,7 @@ typedef void (^PBJVisionBlock)();
         AVCaptureDevice *device = [_currentInput device];
         if (device) {
             [self willChangeValueForKey:@"currentDevice"];
-            _currentDevice = device;
+            [self _setCurrentDevice:device];
             [self didChangeValueForKey:@"currentDevice"];
         }
     }
@@ -2318,7 +2325,7 @@ typedef void (^PBJVisionBlock)();
             AVCaptureDevice *device = [_currentInput device];
             if (device) {
                 [self willChangeValueForKey:@"currentDevice"];
-                _currentDevice = device;
+                [self _setCurrentDevice:device];
                 [self didChangeValueForKey:@"currentDevice"];
             }
         }


### PR DESCRIPTION
These properties aren't initialized with real default values of _currentDevice property. So, it causes a bug because these take the default values as 0 in `[PBJVision sharedInstance]`, it means 

`_exposureMode   = PBJExposureModeLocked;
_focusMode      = PBJFocusModeLocked;`

then, if you try

`PBJVision *vision = [PBJVision sharedInstance];
vision.focusMode    = PBJFocusModeLocked;
vision.exposureMode = PBJExposureModeLocked;`

it never executes lines 469-477 and 493-499 respectively, because the line 465 and 487 always is `false`. But the real values of `_currentDevice.focusMode` and `_currentDevice.exposureMode` are `AVCaptureFocusModeContinuousAutoFocus` and `AVCaptureExposureModeContinuousAutoExposure`.