### PR TITLE
Making photo sessionPreset _captureSessionPreset

### DIFF
--- a/Source/PBJVision.m
+++ b/Source/PBJVision.m
@@ -1113,7 +1113,7 @@ typedef void (^PBJVisionBlock)();
     } else if ( newCaptureOutput && (newCaptureOutput == _captureOutputPhoto) ) {
     
         // specify photo preset
-        sessionPreset = AVCaptureSessionPresetPhoto;
+        sessionPreset = _captureSessionPreset;
     
         // setup photo settings
         NSDictionary *photoSettings = @{AVVideoCodecKey : AVVideoCodecJPEG};


### PR DESCRIPTION
Originally it would alway default to AVCaptureSessionPresetPhoto. Making it configurable allows us to change the photo output settings. 