### PR TITLE
Adds support for AVCapturePhotoOutput in iOS 10+

### DIFF
--- a/Source/PBJVision.m
+++ b/Source/PBJVision.m
@@ -2238,6 +2238,14 @@ typedef void (^PBJVisionBlock)();
 
 #pragma mark - AVCapturePhotoCaptureDelegate
 
+- (void)captureOutput:(AVCapturePhotoOutput *)captureOutput willBeginCaptureForResolvedSettings:(AVCaptureResolvedPhotoSettings *)resolvedSettings {
+    [self _willCapturePhoto];
+}
+
+- (void)captureOutput:(AVCapturePhotoOutput *)captureOutput didFinishCaptureForResolvedSettings:(AVCaptureResolvedPhotoSettings *)resolvedSettings error:(NSError *)error {
+    [self _didCapturePhoto];
+}
+
 - (void)captureOutput:(AVCapturePhotoOutput *)captureOutput
 didFinishProcessingPhotoSampleBuffer:(CMSampleBufferRef)photoSampleBuffer
 previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer


### PR DESCRIPTION
It's worth noting that `highResolutionCaptureEnabled` must be enabled before the `AVCaptureSession startRunning` method is called, which is why I enabled this immediately after `init` rather than exposing this property as a `BOOL` in `PBJVision.h`.